### PR TITLE
Commented out "main" entry in publish-pages.yaml.

### DIFF
--- a/.github/workflows/publish-pages.yaml
+++ b/.github/workflows/publish-pages.yaml
@@ -17,7 +17,7 @@ on:
 
   push:
     branches:
-    - main
+#    - main
     - docs
     paths:
     - '.github/**'


### PR DESCRIPTION
Commented out "main" in publish-pages.yaml to have only docs branch update GitHub Pages site.